### PR TITLE
Ajax通信の共通処理の実装

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,8 @@ gulp.task('eslint', function () {
 			},
 			rules: {
 				'new-cap': [2, {'capIsNewExceptions': ['$.Deferred']}],
-				'quote-props': [2, 'as-needed', { 'keywords': true, 'unnecessary': false }]
+				'quote-props': [2, 'as-needed', { 'keywords': true, 'unnecessary': false }],
+				'no-unused-expressions': [2, { allowShortCircuit: true, allowTernary: true }]
 			}
 		}))
 		.pipe(eslint.format())

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 	<!-- JS -->
 	<script src="bower_components/jquery/dist/jquery.js"></script>
 	<script src="bower_components/Materialize/dist/js/materialize.js"></script>
+	<script src="js/common.js"></script>
 	<script src="js/login.js"></script>
 	<script src="js/calendar.js"></script>
 	<script src="js/index.js"></script>

--- a/js/common.js
+++ b/js/common.js
@@ -1,6 +1,9 @@
 'use strict';
 
-window.$$ = {};
+window.$$ = {
+	apiHost: 'http://localhost:3000',
+	apiVersion: '1.0'
+};
 
 (function ($, $$) {
 
@@ -21,6 +24,71 @@ window.$$ = {};
 		clear: function() {
 			localStorage.clear();
 		}
+	};
+
+	/**
+	 * Ajax通信を行う
+	 *
+	 * @param {Object} ajaxOpt $.ajaxのオプション
+	 * @return {Promise} jqXHRオブジェクト
+	 */
+	$$.ajax = function(ajaxOpt) {
+		var user = $$.storage.getItem('user');
+		var userToken = user ? user.token : '';
+
+		var opt = $.extend({}, ajaxOpt, {
+			headers: {
+				'Content-Type': 'application/json; charset=UTF-8',
+				'X-Meshido-ApiVerion': $$.apiVersion,
+				'X-Meshido-UserToken': userToken
+			},
+			dataType: 'json'
+		});
+
+		opt.url = $$.apiHost + opt.url;
+		opt.data = JSON.stringify(opt.data);
+
+		return ajax(opt);
+	};
+
+	/**
+	 * $.ajax のラッパー
+	 *
+	 * @param {Object} ajaxOpt $.ajaxのオプション
+	 * @param {Function} done Ajax通信成功時の共通処理 (optional)
+	 * @param {Function} fail Ajax通信失敗時の共通処理 (optional)
+	 * @param {Function} always 常に実行する共通処理 (optional)
+	 * @return {Promise} jqXHRオブジェクト
+	 */
+	var ajax = function (ajaxOpt, done, fail, always) {
+		var jqXHR = $.ajax(ajaxOpt);
+		var defer = $.Deferred();
+
+		jqXHR.done(function(data, statusText, jqXHR) {
+			console.log(data, statusText, jqXHR);
+
+			if (done && done(data, statusText, jqXHR) === false) {
+				return;
+			}
+
+			defer.resolveWith(this, arguments);
+		});
+
+		jqXHR.fail(function(jqXHR, statusText, errorThrown) {
+			console.log(jqXHR, statusText, errorThrown);
+
+			if (fail && fail(jqXHR, statusText, errorThrown) === false) {
+				return;
+			}
+
+			defer.rejectWith(this, arguments);
+		});
+
+		jqXHR.always(function() {
+			always && always();
+		});
+
+		return $.extend({}, jqXHR, defer.promise());
 	};
 
 })(jQuery, window.$$);

--- a/js/common.js
+++ b/js/common.js
@@ -1,0 +1,26 @@
+'use strict';
+
+window.$$ = {};
+
+(function ($, $$) {
+
+	/**
+	 * localStorage のラッパー
+	 */
+	$$.storage = {
+		setItem: function (key, value) {
+			localStorage.setItem(key, JSON.stringify(value));
+		},
+		getItem: function (key) {
+			var item = localStorage.getItem(key);
+			return item === null ? null : JSON.parse(item);
+		},
+		removeItem: function (key) {
+			localStorage.removeItem(key);
+		},
+		clear: function() {
+			localStorage.clear();
+		}
+	};
+
+})(jQuery, window.$$);

--- a/js/common.js
+++ b/js/common.js
@@ -6,7 +6,6 @@ window.$$ = {
 };
 
 (function ($, $$) {
-
 	/**
 	 * localStorage のラッパー
 	 */
@@ -21,7 +20,7 @@ window.$$ = {
 		removeItem: function (key) {
 			localStorage.removeItem(key);
 		},
-		clear: function() {
+		clear: function () {
 			localStorage.clear();
 		}
 	};
@@ -32,7 +31,7 @@ window.$$ = {
 	 * @param {Object} ajaxOpt $.ajaxのオプション
 	 * @return {Promise} jqXHRオブジェクト
 	 */
-	$$.ajax = function(ajaxOpt) {
+	$$.ajax = function (ajaxOpt) {
 		var user = $$.storage.getItem('user');
 		var userToken = user ? user.token : '';
 
@@ -60,11 +59,11 @@ window.$$ = {
 	 * @param {Function} always 常に実行する共通処理 (optional)
 	 * @return {Promise} jqXHRオブジェクト
 	 */
-	var ajax = function (ajaxOpt, done, fail, always) {
+	function ajax(ajaxOpt, done, fail, always) {
 		var jqXHR = $.ajax(ajaxOpt);
 		var defer = $.Deferred();
 
-		jqXHR.done(function(data, statusText, jqXHR) {
+		jqXHR.done(function (data, statusText, jqXHR) {
 			console.log(data, statusText, jqXHR);
 
 			if (done && done(data, statusText, jqXHR) === false) {
@@ -74,7 +73,7 @@ window.$$ = {
 			defer.resolveWith(this, arguments);
 		});
 
-		jqXHR.fail(function(jqXHR, statusText, errorThrown) {
+		jqXHR.fail(function (jqXHR, statusText, errorThrown) {
 			console.log(jqXHR, statusText, errorThrown);
 
 			if (fail && fail(jqXHR, statusText, errorThrown) === false) {
@@ -84,11 +83,10 @@ window.$$ = {
 			defer.rejectWith(this, arguments);
 		});
 
-		jqXHR.always(function() {
+		jqXHR.always(function () {
 			always && always();
 		});
 
 		return $.extend({}, jqXHR, defer.promise());
-	};
-
+	}
 })(jQuery, window.$$);

--- a/js/index.js
+++ b/js/index.js
@@ -13,4 +13,16 @@ $(document).ready(function() {
 		$(document).trigger('open-login-modal');
 	}
 
+	// FIXME: 動作確認用の一時コード(あとで削除する)
+	$$.ajax({
+		url: '/',
+		method: 'POST',
+		data: {
+			email: 'taro.yamada@example.com',
+			name: 'Taro Yamada'
+		}
+	}).done(function(json) {
+		console.log('Response = ' + JSON.stringify(json));
+	});
+
 });

--- a/js/index.js
+++ b/js/index.js
@@ -1,26 +1,5 @@
 'use strict';
 
-window.$$ = {};
-
-/**
- * localStorage のラッパー
- */
-$$.storage = {
-	setItem: function (key, value) {
-		localStorage.setItem(key, JSON.stringify(value));
-	},
-	getItem: function (key) {
-		var item = localStorage.getItem(key);
-		return item === null ? null : JSON.parse(item);
-	},
-	removeItem: function (key) {
-		localStorage.removeItem(key);
-	},
-	clear: function() {
-		localStorage.clear();
-	}
-};
-
 $(document).ready(function() {
 
 	var user = $$.storage.getItem('user');

--- a/js/index.js
+++ b/js/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
-$(document).ready(function() {
-
+$(document).ready(function () {
 	var user = $$.storage.getItem('user');
 
 	if (user) {
@@ -21,8 +20,7 @@ $(document).ready(function() {
 			email: 'taro.yamada@example.com',
 			name: 'Taro Yamada'
 		}
-	}).done(function(json) {
+	}).done(function (json) {
 		console.log('Response = ' + JSON.stringify(json));
 	});
-
 });


### PR DESCRIPTION
refs #5 

**やったこと**
- Ajax通信の共通処理の実装
  - $.ajax() に渡すdataパラメータを`JSON.stringify`し、`Content- Type: application/json`でサーバに送信する
  - `X-Meshido-ApiVerion`ヘッダと`X-Meshido-UserToken`ヘッダを付与する
  - APIのエンドポイントURLのホスト部分を補完する
    - (最終的にはホストだけでなく、groupIdも補完する)

**やっていないこと**
- APIのエンドポイントURLのgroupIdの補完 (別途対応予定)

**動作確認手順**

事前準備
1. `git clone https://github.com/TeijigoTeaTime/meshido-backend.git`する
2. `meshido-backend/routes/index.js`に以下の処理を追記する
   
   ``` js
   router.post('/', function (req, res) {
       console.log(req.headers);
       console.log(req.method);
       console.log(req.body);
       res.send({
           status: 'ok'
       });
   });
   ```
3. `npm run start-dev`でサーバを起動する

確認手順
1. `npm install`する
2. `npm start`でアプリを起動する
3. Developer Toolを開く
   - Consoleに`Response = {"status":"ok"}`と出力されていること
4. TeijigoTeaTime/meshido-backendのサーバの出力を確認する
   - 以下のヘッダ、HTTPメソッド、リクエストボディが出力されていること
     
     ```
     { 
     :
     'x-meshido-apiverion': '1.0',
     'x-meshido-usertoken': 'api-token',
     'content-type': 'application/json; charset=UTF-8',
     :
     }
     POST
     { email: 'taro.yamada@example.com', name: 'Taro Yamada' }
     ```
