### PR TITLE
当月のカレンダー情報をサーバから取得する

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -7,10 +7,21 @@ $(document).ready(function () {
 	 * カレンダーを表示するイベント
 	 */
 	$(document).on('display-calendar', function () {
-		$calendar.calendario({
-			checkUpdate : false,
-				caldata : buildCalData(fetchCalendar(2015, 12)),
-			fillEmpty : false
+		var now = new Date();
+		var year = now.getFullYear();
+		var month = now.getMonth() + 1;
+
+		$$.ajax({
+			url: '/group/:group/calendar/year/' + year + '/month/' + month
+		}).done(function (res) {
+			// カレンダーの初期化
+			$calendar.calendario({
+				checkUpdate: false,
+				caldata: buildCalData(res.days),
+				fillEmpty: false
+			});
+		}).fail(function () {
+			$$.alert('カレンダーの取得に失敗しました。');
 		});
 	});
 
@@ -37,6 +48,7 @@ $(document).ready(function () {
 		$('#custom-year').html($calendar.calendario('getYear'));
 		$('#custom-month').html($calendar.calendario('getMonthName'));
 	}
+
 	/**
 	 * Calendarioに与えるcaldataを生成する
 	 *
@@ -59,73 +71,5 @@ $(document).ready(function () {
 
 		return events;
 	}
-
-	/**
-	 * サーバからカレンダーを取得する
-	 *
-	 * @param {Number} year 年
-	 * @param {Number} month 月
-	 */
-	function fetchCalendar(year, month) {
-		// TODO: サーバから取得する
-		// サーバからのレスポンスのフォーマットは
-		// https://github.com/TeijigoTeaTime/meshido-backend#カレンダー-get-groupgroupcalendar
-		// を参照
-		return {
-			"v": "0.1",
-			// 一ヶ月分のカレンダーと各イベントの状態
-			"days": [
-				{
-					"dayOfMonth": (new Date().getDate()),    // 日にち
-					"weekday": ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'][new Date().getDay()],   // 曜日
-					"events": {
-						"lunch": {
-							"hasJoined": true,   // 参加済みか
-							"isFixed": true,     // 確定済みのイベントか
-							"participantCount": 3,  // 参加者数
-							"_links": {}
-						},
-						"dinner": {
-							"hasJoined": false,
-							"isFixed": true,
-							"participantCount": 4,
-							"_links": {}
-						}
-					}
-				},
-				{
-					"dayOfMonth": (new Date().getDate() + 1),    // 日にち
-					"weekday": ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'][new Date().getDay() + 1],   // 曜日
-					"events": {
-						"lunch": {
-							"hasJoined": false,   // 参加済みか
-							"isFixed": false,     // 確定済みのイベントか
-							"participantCount": 5,  // 参加者数
-							"_links": {}
-						},
-						"dinner": {
-							"hasJoined": true,
-							"isFixed": false,
-							"participantCount": 6,
-							"_links": {}
-						}
-					}
-				}
-			],
-			"_links": {
-				"self" : {
-					"href": "/group/group12345/calendar/year/2015/month/12",
-				},
-				"next" : {
-					"href": "/group/group12345/calendar/year/2016/month/1",
-				},
-				"prev" : {
-					"href": "/group/group12345/calendar/year/2015/month/11",
-				}
-			},
-			"_embeded": {}
-		};
-	}
-	console.log('display-calendar');
 });
 

--- a/js/common.js
+++ b/js/common.js
@@ -2,7 +2,8 @@
 
 window.$$ = {
 	apiHost: 'http://localhost:3000',
-	apiVersion: '1.0'
+	apiVersion: '1.0',
+	userGroup: 'test1'
 };
 
 (function ($, $$) {
@@ -43,7 +44,7 @@ window.$$ = {
 			dataType: 'json'
 		});
 
-		opt.url = $$.apiHost + opt.url;
+		opt.url = $$.apiHost + opt.url.replace(':group', window.$$.userGroup);
 		opt.data = JSON.stringify(opt.data);
 
 		return ajax(opt);

--- a/js/login.js
+++ b/js/login.js
@@ -56,7 +56,7 @@ $(document).ready(function () {
 			url: '/login',
 			method: 'POST',
 			data: {
-				group: 'test1',
+				group: window.$$.userGroup,
 				email: email,
 				name: name
 			}


### PR DESCRIPTION
refs #20 

**やったこと**

ログイン後、カレンダーを表示する際に、サーバから当月のカレンダー情報を取得し、 `buildCalData`関数の引数に与える

**動作確認手順**
1. ローカルでバックエンドサーバを起動する
   1. mongodbのVMを起動する
   2. meshido-backendのコンソールで以下のコマンドを実行する
      - `npm install`
      - `npm init-db`
      - `npm start-dev-win`
2. `npm start`でアプリを起動し、Developer TookでLocalStorageのデータをすべて削除する
3. アプリを停止する
4. `npm start`でアプリを起動する
5. ログインする
   - **当月のカレンダーが表示されること**
   - **Developer Toolのコンソールを確認すると、以下のように`days`配列の個数が当月の日付分であること**
     
     ![2015-12-20 0 38 35](https://cloud.githubusercontent.com/assets/1461463/11913748/2ef8f0ca-a6b2-11e5-9cd5-f3527c1e70b0.png)

事後作業
- mongodbのVMを停止する
