### PR TITLE
カレンダーを最新の状態に更新するボタンを設置

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -89,7 +89,7 @@ header .title {
 
 .msd-container .custom-header nav {
 	position: absolute;
-	right: 20px;
+	right: 30px;
 	top: 20px;
 	width:auto;
 	box-shadow: none;
@@ -151,6 +151,10 @@ header .title {
 	content: '\27a6';
 }
 
+.msd-container .custom-header nav .msd-reload-btn i {
+	color: white;
+	padding: 3px 0 0 3px;
+}
 
 .msd-container .fc-calendar {
 	background: rgba(255,255,255,0.1);

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8" />
 	<title>Electron boilerplate</title>
 	<!-- font -->
-	<link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+	<link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 	<!-- CSS -->
 	<link rel="stylesheet" href="bower_components/Materialize/dist/css/materialize.css" />
 	<link rel="stylesheet" type="text/css" href="bower_components/Calendario/css/calendar.css" />

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
 	<meta charset="utf-8" />
 	<title>Electron boilerplate</title>
+	<!-- font -->
+	<link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<!-- CSS -->
 	<link rel="stylesheet" href="bower_components/Materialize/dist/css/materialize.css" />
 	<link rel="stylesheet" type="text/css" href="bower_components/Calendario/css/calendar.css" />
@@ -56,10 +58,15 @@
 				<h3 class="custom-month-year">
 					<span id="custom-month" class="custom-month"></span>
 					<span id="custom-year" class="custom-year"></span>
-					<nav>
+					<nav class="msd-js-calendar-nav hide">
+						<!--
 						<span id="custom-prev" class="custom-prev"></span>
 						<span id="custom-next" class="custom-next"></span>
-						<span id="custom-current" class="custom-current" title="Go to current date"></span>
+						<span id="custom-current" class="custom-current"></span>
+						-->
+						<span id="msd-reload-calendar" class="msd-reload-btn">
+							<i class="material-icons">autorenew</i>
+						</span>
 					</nav>
 				</h3>
 			</div>

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -7,19 +7,21 @@ $(document).ready(function () {
 	 * カレンダーを表示するイベント
 	 */
 	$(document).on('display-calendar', function () {
-		var now = new Date();
-		var year = now.getFullYear();
-		var month = now.getMonth() + 1;
+		// カレンダーの初期化
+		$calendar.calendario({
+			checkUpdate: false,
+			fillEmpty: false,
+			caldata: {}
+		});
+
+		var today = new Date();
+		var year = today.getFullYear();
+		var month = today.getMonth() + 1;
 
 		$$.ajax({
 			url: '/group/:group/calendar/year/' + year + '/month/' + month
 		}).done(function (res) {
-			// カレンダーの初期化
-			$calendar.calendario({
-				checkUpdate: false,
-				fillEmpty: false,
-				caldata: {}
-			});
+			// イベント情報（ボタン、人数）を描画
 			$calendar.calendario('setData',  buildCalData(year, month, res.days));
 		}).fail(function () {
 			$$.alert('カレンダーの取得に失敗しました。');

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -22,7 +22,7 @@ $(document).ready(function () {
 			url: '/group/:group/calendar/year/' + year + '/month/' + month
 		}).done(function (res) {
 			// イベント情報（ボタン、人数）を描画
-			$calendar.calendario('setData',  buildCalData(year, month, res.days));
+			$calendar.calendario('setData', buildCalData(year, month, res.days));
 		}).fail(function () {
 			$$.alert('カレンダーの取得に失敗しました。');
 		});

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -17,15 +17,17 @@ $(document).ready(function () {
 			// カレンダーの初期化
 			$calendar.calendario({
 				checkUpdate: false,
-				caldata: buildCalData(year, month, res.days),
-				fillEmpty: false
+				fillEmpty: false,
+				caldata: {}
 			});
+			$calendar.calendario('setData',  buildCalData(year, month, res.days));
 		}).fail(function () {
 			$$.alert('カレンダーの取得に失敗しました。');
 		});
 	});
 
 	$(document).on('finish.calendar.calendario', function () {
+		$('.msd-js-calendar-nav').removeClass('hide');
 		updateYearMonth();
 	});
 
@@ -39,6 +41,10 @@ $(document).ready(function () {
 
 	$('#custom-current').on('click', function () {
 		$calendar.calendario('gotoNow', updateYearMonth);
+	});
+
+	$('#msd-reload-calendar').on('click', function () {
+		$(document).trigger('display-calendar');
 	});
 
 	/**


### PR DESCRIPTION
refs #21 

**やったこと**
#21 の本文の通り。

**動作確認**

事前作業
- mongodbのVMを起動する（`vagrant up`）
- mondogbを初期化する（`npm run init-db`）
- バックエンドサーバを起動する（`npm run start-dev-win`）

確認手順
1. `npm start`でアプリを起動する
2. Developer ToolでLocalStorageのデータを削除し、アプリを閉じる
3. `npm start`でアプリを起動する（アプリ①）
   - **ウインドウ右上にボタンが何も表示されていないこと**
   - **イベントがすべて未参加状態であること**
4. ログインする
   - **ウインドウ右上にReloadボタンが表示されること**
5. 別のコンソールで、`npm start`で２つ目のアプリを起動する（アプリ②）
   - **イベントがすべて未参加状態であること**
6. アプリ①で適当に、イベントを参加状態にする
7. アプリ②でReloadボタンを押下する
   - **イベントの参加状態が、アプリ①と同じ状態に更新されること**

事後作業
- mongodbのVMを停止する（`vagrant halt`）
