### PR TITLE
Windows用バイナリのビルドオプションの変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "postinstall": "bower install",
     "start": "electron .",
-    "build:mac": "electron-packager . 'Meshido' --platform=darwin --arch=x64 --version=0.35.0 --out=dist --ignore='^/dist$' --overwrite",
-    "build:win": "electron-packager . 'Meshido' --platform=win32  --arch=x64 --version=0.35.0 --out=dist --ignore='^/dist$' --overwrite",
+    "build:mac": "electron-packager . 'Meshido' --platform=darwin --arch=x64 --version=0.36.1 --out=dist --ignore='^/dist$' --overwrite",
+    "build:win": "electron-packager . 'Meshido' --platform=win32  --arch=ia32 --version=0.36.1 --out=dist --ignore='^/dist$' --overwrite",
     "bower": "bower",
     "gulp": "gulp",
     "lint": "gulp lint"


### PR DESCRIPTION
windowsでのビルド用のオプションを変更
- `--arch=is32`

ついでに、electornのバージョンを最新版(`0.36.1`)に変更
