### PR TITLE
スクロールバーが表示されないようにウィンドウサイズを変更

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ function onClosed() {
 function createMainWindow() {
 	const win = new electron.BrowserWindow({
 		width: 880,
-		height: 600,
+		height: 650,
 		'node-integration': false
 	});
 


### PR DESCRIPTION
掲題の通り対応しました。
- width -> 880px
- height -> 650px

@masato-n WindowsPCで、アプリを起動し、スクロールバーが表示されないことを確認してください。
