### PR TITLE
Make package size smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "postinstall": "bower install",
     "start": "electron .",
-    "build:mac": "electron-packager . Meshido --platform=darwin --arch=x64 --version=0.36.1 --out=dist --ignore='^/dist$' --overwrite",
-    "build:win": "electron-packager . Meshido --platform=win32  --arch=ia32 --version=0.36.1 --out=dist --ignore='^/dist$' --overwrite",
+    "build:mac": "electron-packager . Meshido --platform=darwin --arch=x64  --version=0.36.1 --out=dist --ignore='^/dist$' --overwrite --prune",
+    "build:win": "electron-packager . Meshido --platform=win32  --arch=ia32 --version=0.36.1 --out=dist --ignore='^/dist$' --overwrite --prune",
     "bower": "bower",
     "gulp": "gulp",
     "lint": "gulp lint"


### PR DESCRIPTION
ビルド成果物(`dist/Meshido-win32-ia32`,`dist/Meshido-darwin-x64`)のサイズを小さくする施策

**やったこと**
- `electron-packager`の **--prune** オプションでdevDependenciesをビルド対象から除外

before

```
$ du -smh dist/Meshido-darwin-x64
177M    dist/Meshido-darwin-x64
```

after (**-64 MB**)

```
$ du -smh dist/Meshido-darwin-x64
113M    dist/Meshido-darwin-x64
```

**動作確認**

事前準備
1. バックエンドを起動
   1. mongodbを起動、初期化
   2. APIサーバを起動
2. `npm start`でアプリを起動し、LocalStorageを一旦削除
3. アプリを停止

確認手順
1. `npm start`でアプリを起動
   - ログインダイアログが表示されること
2. ログインする
   - カレンダーが表示されること
   - 未確定のイベントに参加できること
   - 未確定のイベントをキャンセルできること
